### PR TITLE
avoid NPE in BuildInfo.Print

### DIFF
--- a/buildinfo.go
+++ b/buildinfo.go
@@ -123,14 +123,23 @@ func (i *BuildInfo) JSON() ([]byte, error) {
 
 // Print returns version- and environment information.
 func (i *BuildInfo) Print(program string) string {
+	v := i.VersionInfo
+	if v == nil {
+		v = NewVersionInfo()
+	}
+	e := i.EnvironmentInfo
+	if e == nil {
+		e = NewEnvironmentInfo()
+	}
+
 	return fmt.Sprintf(infoFmt,
 		program,
-		i.VersionInfo.Version,
-		i.VersionInfo.Branch,
-		i.VersionInfo.ShortRevision(),
-		i.EnvironmentInfo.User,
-		i.EnvironmentInfo.Host,
-		i.EnvironmentInfo.Date,
+		v.Version,
+		v.Branch,
+		v.ShortRevision(),
+		e.User,
+		e.Host,
+		e.Date,
 		GoVersion,
 		GoOS+"/"+GoArch,
 	)

--- a/buildinfo_test.go
+++ b/buildinfo_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"gotest.tools/v3/assert"
+	"gotest.tools/v3/golden"
 )
 
 func TestParse(t *testing.T) {
@@ -237,6 +238,50 @@ func TestBuildInfoEqual(t *testing.T) {
 			got := tc.haveLeft.Equal(tc.haveRight)
 
 			assert.Equal(t, got, tc.want)
+		})
+	}
+}
+
+func TestBuildInfoPrint(t *testing.T) {
+	type testCase struct {
+		have *BuildInfo
+		want string
+	}
+
+	testCases := map[string]testCase{
+		"nil": {
+			have: &BuildInfo{
+				VersionInfo: nil,
+				EnvironmentInfo: &EnvironmentInfo{
+					User: "root",
+					Host: "example.com",
+					Date: time.Unix(123456790, 0),
+				},
+			},
+			want: "print_nil.golden",
+		},
+		"full": {
+			have: &BuildInfo{
+				VersionInfo: &VersionInfo{
+					Version:  "1.2.3",
+					Revision: "deadbeef",
+					Branch:   "unstable",
+				},
+				EnvironmentInfo: &EnvironmentInfo{
+					User: "root",
+					Host: "example.com",
+					Date: time.Unix(123456790, 0),
+				},
+			},
+			want: "print_full.golden",
+		},
+	}
+
+	for ctx, tc := range testCases {
+		t.Run(ctx, func(t *testing.T) {
+			got := tc.have.Print("test")
+
+			golden.Assert(t, got, tc.want)
 		})
 	}
 }

--- a/testdata/print_full.golden
+++ b/testdata/print_full.golden
@@ -1,0 +1,6 @@
+test, version 1.2.3 (branch: unstable, revision: deadbeef)
+  build user:       root
+  build host:       example.com
+  build date:       1973-11-29 21:33:10 +0000 UTC
+  go version:       go1.19.13
+  platform:         linux/amd64

--- a/testdata/print_nil.golden
+++ b/testdata/print_nil.golden
@@ -1,0 +1,6 @@
+test, version 0.0.0 (branch: trunk, revision: HEAD)
+  build user:       root
+  build host:       example.com
+  build date:       1973-11-29 21:33:10 +0000 UTC
+  go version:       go1.19.13
+  platform:         linux/amd64


### PR DESCRIPTION
create empty data containers when no information is available to prevent a nil pointer access