### PR TITLE
expose a clone of the embedded build info for others to use.

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,6 @@
+# buildinfo tools
+
+The tools in this module are used to generate code for bootstrapping
+applications for use with [buildinfo](https://github.com/UiP9AV6Y/buildinfo),
+or to extract version information from the current environment for
+embedding into the application build output.

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -3,7 +3,7 @@ module github.com/UiP9AV6Y/buildinfo/tools
 go 1.19
 
 require (
-	github.com/UiP9AV6Y/buildinfo v0.0.0-20231118114407-a0fa77164a70
+	github.com/UiP9AV6Y/buildinfo v0.0.0-20240313195626-97a50b40242a
 	github.com/go-kit/log v0.2.1
 	gotest.tools/v3 v3.5.1
 )

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -1,5 +1,5 @@
-github.com/UiP9AV6Y/buildinfo v0.0.0-20231118114407-a0fa77164a70 h1:FY43764yCaKPS6MGdKE6Co/9rdt4I8vXqgO+4ieEZOU=
-github.com/UiP9AV6Y/buildinfo v0.0.0-20231118114407-a0fa77164a70/go.mod h1:xOw/nvP1ol539jLd1YV6oueyGt8h7RaQ0+r2PHDhidk=
+github.com/UiP9AV6Y/buildinfo v0.0.0-20240313195626-97a50b40242a h1:a2IDIfV2Smoe+mwj553zsTglo67fsMPN05tjBRpT4J0=
+github.com/UiP9AV6Y/buildinfo v0.0.0-20240313195626-97a50b40242a/go.mod h1:JQKMnAuoFntCA2Lrxfl46yZRuhPPUNsq4Z9Dh03uqPA=
 github.com/go-kit/log v0.2.1 h1:MRVx0/zhvdseW+Gza6N9rVzU/IVzaeE1SFI4raAhmBU=
 github.com/go-kit/log v0.2.1/go.mod h1:NwTd00d/i8cPZ3xOwwiv2PO5MOcx78fFErGNcVmBjv0=
 github.com/go-logfmt/logfmt v0.5.1 h1:otpy5pqBCBZ1ng9RQ0dPu4PN7ba75Y/aA+UpowDyNVA=

--- a/tools/renderer/golang/embed.go
+++ b/tools/renderer/golang/embed.go
@@ -37,6 +37,12 @@ func Version() string {
 func Print(program string) string {
 	return buildInfo.Print(program)
 }
+
+// BuildInfo creates an independent copy of the internal
+// build information.
+func BuildInfo() *buildinfo.BuildInfo {
+	return buildInfo.Clone()
+}
 `
 )
 

--- a/tools/renderer/golang/testdata/args.golden
+++ b/tools/renderer/golang/testdata/args.golden
@@ -25,3 +25,9 @@ func Version() string {
 func Print(program string) string {
 	return buildInfo.Print(program)
 }
+
+// BuildInfo creates an independent copy of the internal
+// build information.
+func BuildInfo() *buildinfo.BuildInfo {
+	return buildInfo.Clone()
+}

--- a/tools/renderer/golang/testdata/embed.golden
+++ b/tools/renderer/golang/testdata/embed.golden
@@ -25,3 +25,9 @@ func Version() string {
 func Print(program string) string {
 	return buildInfo.Print(program)
 }
+
+// BuildInfo creates an independent copy of the internal
+// build information.
+func BuildInfo() *buildinfo.BuildInfo {
+	return buildInfo.Clone()
+}

--- a/tools/version/version.go
+++ b/tools/version/version.go
@@ -25,3 +25,9 @@ func Version() string {
 func Print(program string) string {
 	return buildInfo.Print(program)
 }
+
+// BuildInfo creates an independent copy of the internal
+// build information.
+func BuildInfo() *buildinfo.BuildInfo {
+	return buildInfo.Clone()
+}


### PR DESCRIPTION
this allows third parties to process the build information.